### PR TITLE
Add UI to show weddings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ dependencies {
 }
 
 shadowJar {
-    archiveFileName = 'addressbook.jar'
+    archiveFileName = 'WedLinker.jar'
 }
 
 defaultTasks 'clean', 'test'

--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -9,6 +9,7 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.person.Person;
+import seedu.address.model.wedding.Wedding;
 
 /**
  * API of the Logic component
@@ -32,6 +33,9 @@ public interface Logic {
 
     /** Returns an unmodifiable view of the filtered list of persons */
     ObservableList<Person> getFilteredPersonList();
+
+    /** Returns an unmodifiable view of the filtered list of weddings */
+    ObservableList<Wedding> getFilteredWeddingList();
 
     /**
      * Returns the user prefs' address book file path.

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -10,12 +10,14 @@ import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.CommandResult.SwitchView;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.AddressBookParser;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.person.Person;
+import seedu.address.model.wedding.Wedding;
 import seedu.address.storage.Storage;
 
 /**
@@ -69,6 +71,11 @@ public class LogicManager implements Logic {
     @Override
     public ObservableList<Person> getFilteredPersonList() {
         return model.getFilteredPersonList();
+    }
+
+    @Override
+    public ObservableList<Wedding> getFilteredWeddingList() {
+        return model.getFilteredWeddingList();
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -10,7 +10,6 @@ import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
-import seedu.address.logic.commands.CommandResult.SwitchView;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.AddressBookParser;
 import seedu.address.logic.parser.exceptions.ParseException;

--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -20,12 +20,24 @@ public class CommandResult {
     private final boolean exit;
 
     /**
+     * Which view to switch to.
+     */
+    public enum SwitchView {
+        PERSON,
+        WEDDING,
+        NONE
+    }
+
+    private final SwitchView switchView;
+
+    /**
      * Constructs a {@code CommandResult} with the specified fields.
      */
-    public CommandResult(String feedbackToUser, boolean showHelp, boolean exit) {
+    public CommandResult(String feedbackToUser, boolean showHelp, boolean exit, SwitchView view) {
         this.feedbackToUser = requireNonNull(feedbackToUser);
         this.showHelp = showHelp;
         this.exit = exit;
+        switchView = view;
     }
 
     /**
@@ -33,7 +45,23 @@ public class CommandResult {
      * and other fields set to their default value.
      */
     public CommandResult(String feedbackToUser) {
-        this(feedbackToUser, false, false);
+        this(feedbackToUser, false, false, SwitchView.NONE);
+    }
+
+    /**
+     * Constructs a {@code CommandResult} with the specified {@code feedbackToUser}, {@code showHelp}, and
+     * {@code exit} with {@code switchView} set to none.
+     */
+    public CommandResult(String feedbackToUser, boolean showHelp, boolean exit) {
+        this(feedbackToUser, showHelp, exit, SwitchView.NONE);
+    }
+
+    /**
+     * Constructs a {@code CommandResult} with the specified {@code feedbackToUser}, the view the user wants
+     * to switch to and other fields set to their default value.
+     */
+    public CommandResult(String feedbackToUser, SwitchView view) {
+        this(feedbackToUser, false, false, view);
     }
 
     public String getFeedbackToUser() {
@@ -42,6 +70,20 @@ public class CommandResult {
 
     public boolean isShowHelp() {
         return showHelp;
+    }
+
+    /**
+     * Checks if the command requires switching view.
+     */
+    public boolean isSwitchView() {
+        return switch (switchView) {
+        case PERSON, WEDDING -> true;
+        default -> false;
+        };
+    }
+
+    public SwitchView getView() {
+        return switchView;
     }
 
     public boolean isExit() {

--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -104,12 +104,13 @@ public class CommandResult {
         CommandResult otherCommandResult = (CommandResult) other;
         return feedbackToUser.equals(otherCommandResult.feedbackToUser)
                 && showHelp == otherCommandResult.showHelp
-                && exit == otherCommandResult.exit;
+                && exit == otherCommandResult.exit
+                && switchView == otherCommandResult.switchView;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(feedbackToUser, showHelp, exit);
+        return Objects.hash(feedbackToUser, showHelp, exit, switchView);
     }
 
     @Override
@@ -118,6 +119,7 @@ public class CommandResult {
                 .add("feedbackToUser", feedbackToUser)
                 .add("showHelp", showHelp)
                 .add("exit", exit)
+                .add("switchView", switchView)
                 .toString();
     }
 

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
+import seedu.address.logic.commands.CommandResult.SwitchView;
 import seedu.address.model.Model;
 
 /**
@@ -19,6 +20,6 @@ public class ListCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(MESSAGE_SUCCESS);
+        return new CommandResult(MESSAGE_SUCCESS, SwitchView.PERSON);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ListWeddingsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListWeddingsCommand.java
@@ -7,7 +7,7 @@ import seedu.address.logic.commands.CommandResult.SwitchView;
 import seedu.address.model.Model;
 
 /**
- * Lists all persons in the address book to the user.
+ * Lists all weddings in the address book to the user.
  */
 public class ListWeddingsCommand extends Command {
 

--- a/src/main/java/seedu/address/logic/commands/ListWeddingsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListWeddingsCommand.java
@@ -1,0 +1,24 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_WEDDINGS;
+
+import seedu.address.logic.commands.CommandResult.SwitchView;
+import seedu.address.model.Model;
+
+/**
+ * Lists all persons in the address book to the user.
+ */
+public class ListWeddingsCommand extends Command {
+
+    public static final String COMMAND_WORD = "list-weddings";
+
+    public static final String MESSAGE_SUCCESS = "Listed all weddings";
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredWeddingList(PREDICATE_SHOW_ALL_WEDDINGS);
+        return new CommandResult(MESSAGE_SUCCESS, SwitchView.WEDDING);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -21,6 +21,7 @@ import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.ListWeddingsCommand;
 import seedu.address.logic.commands.TagCommand;
 import seedu.address.logic.commands.UnassignWeddingCommand;
 import seedu.address.logic.commands.UntagCommand;
@@ -66,6 +67,7 @@ public class AddressBookParser {
         case ClearCommand.COMMAND_WORD -> new ClearCommand();
         case FindCommand.COMMAND_WORD -> new FindCommandParser().parse(arguments);
         case ListCommand.COMMAND_WORD -> new ListCommand();
+        case ListWeddingsCommand.COMMAND_WORD -> new ListWeddingsCommand();
         case ExitCommand.COMMAND_WORD -> new ExitCommand();
         case HelpCommand.COMMAND_WORD -> new HelpCommand();
         case CreateTagCommand.COMMAND_WORD -> new CreateTagCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -218,7 +218,7 @@ public class MainWindow extends UiPart<Stage> {
     }
 
     /**
-     * Changes the list panel to show the wedding list.
+     * Changes the list panel to show the {@code Wedding} list.
      */
     public void changeToWeddingView() {
         weddingListPanel = new WeddingListPanel(logic.getFilteredWeddingList());
@@ -227,7 +227,7 @@ public class MainWindow extends UiPart<Stage> {
     }
 
     /**
-     * Changes the list panel to show the wedding list.
+     * Changes the list panel to show the {@code Person} list.
      */
     public void changeToPersonView() {
         personListPanel = new PersonListPanel(logic.getFilteredPersonList());

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -14,6 +14,7 @@ import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.Logic;
 import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.CommandResult.SwitchView;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -32,6 +33,7 @@ public class MainWindow extends UiPart<Stage> {
 
     // Independent Ui parts residing in this Ui container
     private PersonListPanel personListPanel;
+    private WeddingListPanel weddingListPanel;
     private ResultDisplay resultDisplay;
     private HelpWindow helpWindow;
 
@@ -42,7 +44,7 @@ public class MainWindow extends UiPart<Stage> {
     private MenuItem helpMenuItem;
 
     @FXML
-    private StackPane personListPanelPlaceholder;
+    private StackPane listPanelPlaceholder;
 
     @FXML
     private StackPane resultDisplayPlaceholder;
@@ -111,7 +113,7 @@ public class MainWindow extends UiPart<Stage> {
      */
     void fillInnerParts() {
         personListPanel = new PersonListPanel(logic.getFilteredPersonList());
-        personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
+        listPanelPlaceholder.getChildren().add(personListPanel.getRoot());
 
         resultDisplay = new ResultDisplay();
         resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());
@@ -186,6 +188,10 @@ public class MainWindow extends UiPart<Stage> {
                 handleExit();
             }
 
+            if (commandResult.isSwitchView()) {
+                switchView(commandResult.getView());
+            }
+
             return commandResult;
         } catch (CommandException | ParseException e) {
             logger.info("An error occurred while executing command: " + commandText);
@@ -193,4 +199,40 @@ public class MainWindow extends UiPart<Stage> {
             throw e;
         }
     }
+
+    /**
+     * Switches the view shown to the user.
+     * @param switchView The view that should be shown.
+     */
+    public void switchView(SwitchView switchView) {
+        switch (switchView) {
+        case PERSON:
+            changeToPersonView();
+            break;
+        case WEDDING:
+            changeToWeddingView();
+            break;
+        default:
+            throw new UnsupportedOperationException("Invalid view selected.");
+        }
+    }
+
+    /**
+     * Changes the list panel to show the wedding list.
+     */
+    public void changeToWeddingView() {
+        weddingListPanel = new WeddingListPanel(logic.getFilteredWeddingList());
+        listPanelPlaceholder.getChildren().clear();
+        listPanelPlaceholder.getChildren().add(weddingListPanel.getRoot());
+    }
+
+    /**
+     * Changes the list panel to show the wedding list.
+     */
+    public void changeToPersonView() {
+        personListPanel = new PersonListPanel(logic.getFilteredPersonList());
+        listPanelPlaceholder.getChildren().clear();
+        listPanelPlaceholder.getChildren().add(personListPanel.getRoot());
+    }
+
 }

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -115,6 +115,8 @@ public class MainWindow extends UiPart<Stage> {
         personListPanel = new PersonListPanel(logic.getFilteredPersonList());
         listPanelPlaceholder.getChildren().add(personListPanel.getRoot());
 
+        weddingListPanel = new WeddingListPanel(logic.getFilteredWeddingList());
+
         resultDisplay = new ResultDisplay();
         resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());
 
@@ -221,7 +223,7 @@ public class MainWindow extends UiPart<Stage> {
      * Changes the list panel to show the {@code Wedding} list.
      */
     public void changeToWeddingView() {
-        weddingListPanel = new WeddingListPanel(logic.getFilteredWeddingList());
+        weddingListPanel.updateWeddingList(logic.getFilteredWeddingList());
         listPanelPlaceholder.getChildren().clear();
         listPanelPlaceholder.getChildren().add(weddingListPanel.getRoot());
     }
@@ -230,7 +232,7 @@ public class MainWindow extends UiPart<Stage> {
      * Changes the list panel to show the {@code Person} list.
      */
     public void changeToPersonView() {
-        personListPanel = new PersonListPanel(logic.getFilteredPersonList());
+        personListPanel.updatePersonList(logic.getFilteredPersonList());
         listPanelPlaceholder.getChildren().clear();
         listPanelPlaceholder.getChildren().add(personListPanel.getRoot());
     }

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -44,7 +44,7 @@ public class PersonCard extends UiPart<Region> {
     private FlowPane weddings;
 
     /**
-     * Creates a {@code PersonCode} with the given {@code Person} and index to display.
+     * Creates a {@code PersonCard} with the given {@code Person} and index to display.
      */
     public PersonCard(Person person, int displayedIndex) {
         super(FXML);

--- a/src/main/java/seedu/address/ui/PersonListPanel.java
+++ b/src/main/java/seedu/address/ui/PersonListPanel.java
@@ -9,7 +9,6 @@ import javafx.scene.control.ListView;
 import javafx.scene.layout.Region;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.person.Person;
-import seedu.address.model.wedding.Wedding;
 
 /**
  * Panel containing the list of persons.

--- a/src/main/java/seedu/address/ui/PersonListPanel.java
+++ b/src/main/java/seedu/address/ui/PersonListPanel.java
@@ -9,6 +9,7 @@ import javafx.scene.control.ListView;
 import javafx.scene.layout.Region;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.person.Person;
+import seedu.address.model.wedding.Wedding;
 
 /**
  * Panel containing the list of persons.
@@ -27,6 +28,13 @@ public class PersonListPanel extends UiPart<Region> {
         super(FXML);
         personListView.setItems(personList);
         personListView.setCellFactory(listView -> new PersonListViewCell());
+    }
+
+    /**
+     * Updates the {@code PersonListView} with an updated list of persons.
+     */
+    public void updatePersonList(ObservableList<Person> personList) {
+        personListView.setItems(personList);
     }
 
     /**

--- a/src/main/java/seedu/address/ui/UiManager.java
+++ b/src/main/java/seedu/address/ui/UiManager.java
@@ -19,14 +19,6 @@ public class UiManager implements Ui {
 
     public static final String ALERT_DIALOG_PANE_FIELD_ID = "alertDialogPane";
 
-    /**
-     * The set of possible views.
-     */
-    public static enum View {
-        PERSON,
-        WEDDING
-    }
-
     private static final Logger logger = LogsCenter.getLogger(UiManager.class);
     private static final String ICON_APPLICATION = "/images/address_book_32.png";
 

--- a/src/main/java/seedu/address/ui/UiManager.java
+++ b/src/main/java/seedu/address/ui/UiManager.java
@@ -19,6 +19,14 @@ public class UiManager implements Ui {
 
     public static final String ALERT_DIALOG_PANE_FIELD_ID = "alertDialogPane";
 
+    /**
+     * The set of possible views.
+     */
+    public static enum View {
+        PERSON,
+        WEDDING
+    }
+
     private static final Logger logger = LogsCenter.getLogger(UiManager.class);
     private static final String ICON_APPLICATION = "/images/address_book_32.png";
 

--- a/src/main/java/seedu/address/ui/WeddingCard.java
+++ b/src/main/java/seedu/address/ui/WeddingCard.java
@@ -7,7 +7,7 @@ import javafx.scene.layout.Region;
 import seedu.address.model.wedding.Wedding;
 
 /**
- * A UI component that displays information of a {@code Person}.
+ * A UI component that displays information of a {@code Wedding}.
  */
 public class WeddingCard extends UiPart<Region> {
 
@@ -31,7 +31,7 @@ public class WeddingCard extends UiPart<Region> {
     private Label id;
 
     /**
-     * Creates a {@code PersonCode} with the given {@code Person} and index to display.
+     * Creates a {@code WeddingCard} with the given {@code Wedding} and index to display.
      */
     public WeddingCard(Wedding wedding, int displayedIndex) {
         super(FXML);

--- a/src/main/java/seedu/address/ui/WeddingCard.java
+++ b/src/main/java/seedu/address/ui/WeddingCard.java
@@ -1,0 +1,42 @@
+package seedu.address.ui;
+
+import javafx.fxml.FXML;
+import javafx.scene.control.Label;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Region;
+import seedu.address.model.wedding.Wedding;
+
+/**
+ * A UI component that displays information of a {@code Person}.
+ */
+public class WeddingCard extends UiPart<Region> {
+
+    private static final String FXML = "WeddingListCard.fxml";
+
+    /**
+     * Note: Certain keywords such as "location" and "resources" are reserved keywords in JavaFX.
+     * As a consequence, UI elements' variable names cannot be set to such keywords
+     * or an exception will be thrown by JavaFX during runtime.
+     *
+     * @see <a href="https://github.com/se-edu/addressbook-level4/issues/336">The issue on AddressBook level 4</a>
+     */
+
+    public final Wedding wedding;
+
+    @FXML
+    private HBox cardPane;
+    @FXML
+    private Label name;
+    @FXML
+    private Label id;
+
+    /**
+     * Creates a {@code PersonCode} with the given {@code Person} and index to display.
+     */
+    public WeddingCard(Wedding wedding, int displayedIndex) {
+        super(FXML);
+        this.wedding = wedding;
+        id.setText(displayedIndex + ". ");
+        name.setText(wedding.getWeddingName().toString());
+    }
+}

--- a/src/main/java/seedu/address/ui/WeddingListPanel.java
+++ b/src/main/java/seedu/address/ui/WeddingListPanel.java
@@ -1,0 +1,49 @@
+package seedu.address.ui;
+
+import java.util.logging.Logger;
+
+import javafx.collections.ObservableList;
+import javafx.fxml.FXML;
+import javafx.scene.control.ListCell;
+import javafx.scene.control.ListView;
+import javafx.scene.layout.Region;
+import seedu.address.commons.core.LogsCenter;
+import seedu.address.model.wedding.Wedding;
+
+/**
+ * Panel containing the list of persons.
+ */
+public class WeddingListPanel extends UiPart<Region> {
+    private static final String FXML = "WeddingListPanel.fxml";
+    private final Logger logger = LogsCenter.getLogger(WeddingListPanel.class);
+
+    @FXML
+    private ListView<Wedding> weddingListView;
+
+    /**
+     * Creates a {@code PersonListPanel} with the given {@code ObservableList}.
+     */
+    public WeddingListPanel(ObservableList<Wedding> weddingList) {
+        super(FXML);
+        weddingListView.setItems(weddingList);
+        weddingListView.setCellFactory(listView -> new WeddingListViewCell());
+    }
+
+    /**
+     * Custom {@code ListCell} that displays the graphics of a {@code Person} using a {@code PersonCard}.
+     */
+    class WeddingListViewCell extends ListCell<Wedding> {
+        @Override
+        protected void updateItem(Wedding wedding, boolean empty) {
+            super.updateItem(wedding, empty);
+
+            if (empty || wedding == null) {
+                setGraphic(null);
+                setText(null);
+            } else {
+                setGraphic(new WeddingCard(wedding, getIndex() + 1).getRoot());
+            }
+        }
+    }
+
+}

--- a/src/main/java/seedu/address/ui/WeddingListPanel.java
+++ b/src/main/java/seedu/address/ui/WeddingListPanel.java
@@ -11,7 +11,7 @@ import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.wedding.Wedding;
 
 /**
- * Panel containing the list of persons.
+ * Panel containing the list of weddings.
  */
 public class WeddingListPanel extends UiPart<Region> {
     private static final String FXML = "WeddingListPanel.fxml";
@@ -21,7 +21,7 @@ public class WeddingListPanel extends UiPart<Region> {
     private ListView<Wedding> weddingListView;
 
     /**
-     * Creates a {@code PersonListPanel} with the given {@code ObservableList}.
+     * Creates a {@code WeddingListPanel} with the given {@code ObservableList}.
      */
     public WeddingListPanel(ObservableList<Wedding> weddingList) {
         super(FXML);
@@ -30,7 +30,7 @@ public class WeddingListPanel extends UiPart<Region> {
     }
 
     /**
-     * Custom {@code ListCell} that displays the graphics of a {@code Person} using a {@code PersonCard}.
+     * Custom {@code ListCell} that displays the graphics of a {@code Wedding} using a {@code WeddingCard}.
      */
     class WeddingListViewCell extends ListCell<Wedding> {
         @Override

--- a/src/main/java/seedu/address/ui/WeddingListPanel.java
+++ b/src/main/java/seedu/address/ui/WeddingListPanel.java
@@ -30,6 +30,13 @@ public class WeddingListPanel extends UiPart<Region> {
     }
 
     /**
+     * Updates the {@code WeddingListView} with an updated list of weddings.
+     */
+    public void updateWeddingList(ObservableList<Wedding> weddingList) {
+        weddingListView.setItems(weddingList);
+    }
+
+    /**
      * Custom {@code ListCell} that displays the graphics of a {@code Wedding} using a {@code WeddingCard}.
      */
     class WeddingListViewCell extends ListCell<Wedding> {

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -46,11 +46,11 @@
           </padding>
         </StackPane>
 
-        <VBox fx:id="personList" styleClass="pane-with-border" minWidth="340" prefWidth="340" VBox.vgrow="ALWAYS">
+        <VBox fx:id="entityList" styleClass="pane-with-border" minWidth="340" prefWidth="340" VBox.vgrow="ALWAYS">
           <padding>
             <Insets top="10" right="10" bottom="10" left="10" />
           </padding>
-          <StackPane fx:id="personListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+          <StackPane fx:id="listPanelPlaceholder" VBox.vgrow="ALWAYS"/>
         </VBox>
 
         <StackPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER" />

--- a/src/main/resources/view/WeddingListCard.fxml
+++ b/src/main/resources/view/WeddingListCard.fxml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.layout.ColumnConstraints?>
+<?import javafx.scene.layout.GridPane?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.Region?>
+<?import javafx.scene.layout.RowConstraints?>
+<?import javafx.scene.layout.VBox?>
+
+<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/22" xmlns:fx="http://javafx.com/fxml/1">
+  <GridPane HBox.hgrow="ALWAYS">
+    <columnConstraints>
+      <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
+    </columnConstraints>
+    <VBox alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0">
+      <padding>
+        <Insets bottom="5" left="15" right="5" top="5" />
+      </padding>
+
+      <HBox alignment="CENTER_LEFT" spacing="0.5">
+        <Label fx:id="id" styleClass="cell_big_label">
+          <minWidth>
+            <!-- Ensures that the label text is never truncated -->
+            <Region fx:constant="USE_PREF_SIZE" />
+          </minWidth>
+        </Label>
+        <Label fx:id="name" styleClass="cell_big_label" text="\$first" />
+      </HBox>
+    </VBox>
+      <rowConstraints>
+         <RowConstraints />
+      </rowConstraints>
+  </GridPane>
+</HBox>

--- a/src/main/resources/view/WeddingListPanel.fxml
+++ b/src/main/resources/view/WeddingListPanel.fxml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.control.ListView?>
+<?import javafx.scene.layout.VBox?>
+
+<VBox xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
+  <ListView fx:id="weddingListView" VBox.vgrow="ALWAYS" />
+</VBox>

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -87,6 +87,11 @@ public class LogicManagerTest {
         assertThrows(UnsupportedOperationException.class, () -> logic.getFilteredPersonList().remove(0));
     }
 
+    @Test
+    public void getFilteredWeddingList_modifyList_throwsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, () -> logic.getFilteredWeddingList().remove(0));
+    }
+
     /**
      * Executes the command and confirms that
      * - no exceptions are thrown <br>

--- a/src/test/java/seedu/address/logic/commands/CommandResultTest.java
+++ b/src/test/java/seedu/address/logic/commands/CommandResultTest.java
@@ -7,6 +7,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.logic.commands.CommandResult.SwitchView;
+
 public class CommandResultTest {
     @Test
     public void equals() {
@@ -15,6 +17,12 @@ public class CommandResultTest {
         // same values -> returns true
         assertTrue(commandResult.equals(new CommandResult("feedback")));
         assertTrue(commandResult.equals(new CommandResult("feedback", false, false)));
+        assertTrue(commandResult.equals(new CommandResult("feedback", false, false,
+                SwitchView.NONE)));
+
+        // same object -> returns true
+        assertEquals(commandResult.isSwitchView(), new CommandResult("feedback", false, false,
+                SwitchView.NONE).isSwitchView());
 
         // same object -> returns true
         assertTrue(commandResult.equals(commandResult));
@@ -29,10 +37,22 @@ public class CommandResultTest {
         assertFalse(commandResult.equals(new CommandResult("different")));
 
         // different showHelp value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", true, false)));
+        assertFalse(commandResult.equals(new CommandResult("feedback", true, false,
+                SwitchView.NONE)));
 
         // different exit value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", false, true)));
+        assertFalse(commandResult.equals(new CommandResult("feedback", false, true,
+                SwitchView.NONE)));
+
+        // different switchView value -> returns false
+        assertFalse(commandResult.equals(new CommandResult("feedback", false, false,
+                SwitchView.WEDDING)));
+        assertFalse(commandResult.equals(new CommandResult("feedback", false, false,
+                SwitchView.PERSON)));
+
+        // different switchView value -> returns false
+        assertNotEquals(commandResult.isSwitchView(), new CommandResult("feedback", false, false,
+                SwitchView.PERSON).isSwitchView());
     }
 
     @Test
@@ -50,6 +70,10 @@ public class CommandResultTest {
 
         // different exit value -> returns different hashcode
         assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, true).hashCode());
+
+        // different exit value -> returns different hashcode
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, false,
+                SwitchView.PERSON).hashCode());
     }
 
     @Test
@@ -57,7 +81,7 @@ public class CommandResultTest {
         CommandResult commandResult = new CommandResult("feedback");
         String expected = CommandResult.class.getCanonicalName() + "{feedbackToUser="
                 + commandResult.getFeedbackToUser() + ", showHelp=" + commandResult.isShowHelp()
-                + ", exit=" + commandResult.isExit() + "}";
+                + ", exit=" + commandResult.isExit() + ", switchView=" + commandResult.getView() + "}";
         assertEquals(expected, commandResult.toString());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -28,12 +28,14 @@ public class ListCommandTest {
 
     @Test
     public void execute_listIsNotFiltered_showsSameList() {
-        assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
+        CommandResult actualCommandResult = new ListCommand().execute(model);
+        assertCommandSuccess(new ListCommand(), model, actualCommandResult, expectedModel);
     }
 
     @Test
     public void execute_listIsFiltered_showsEverything() {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
-        assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
+        CommandResult actualCommandResult = new ListCommand().execute(model);
+        assertCommandSuccess(new ListCommand(), model, actualCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ListWeddingsCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListWeddingsCommandIntegrationTest.java
@@ -1,8 +1,6 @@
 package seedu.address.logic.commands;
 
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.BeforeEach;

--- a/src/test/java/seedu/address/logic/commands/ListWeddingsCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListWeddingsCommandIntegrationTest.java
@@ -1,0 +1,36 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for ListCommand.
+ */
+public class ListWeddingsCommandIntegrationTest {
+
+    private Model model;
+    private Model expectedModel;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+    }
+
+    @Test
+    public void execute_listIsNotFiltered_showsSameList() {
+        CommandResult actualCommandResult = new ListWeddingsCommand().execute(model);
+        assertCommandSuccess(new ListWeddingsCommand(), model, actualCommandResult, expectedModel);
+    }
+
+    // Todo: if wedding filtering is done in the wedding view, have tests for filtered list
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -15,14 +15,22 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.AssignWeddingCommand;
 import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.CreateTagCommand;
+import seedu.address.logic.commands.CreateWeddingCommand;
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.DeleteTagCommand;
+import seedu.address.logic.commands.DeleteWeddingCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.ListWeddingsCommand;
 import seedu.address.logic.commands.TagCommand;
+import seedu.address.logic.commands.UnassignWeddingCommand;
+import seedu.address.logic.commands.UntagCommand;
 import seedu.address.logic.commands.findcommand.FindCommand;
 import seedu.address.logic.commands.findcommand.FindNameCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -30,6 +38,8 @@ import seedu.address.model.person.Person;
 import seedu.address.model.person.keywordspredicate.NameContainsKeywordsPredicate;
 import seedu.address.model.tag.Tag;
 import seedu.address.model.tag.TagName;
+import seedu.address.model.wedding.Wedding;
+import seedu.address.model.wedding.WeddingName;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
 import seedu.address.testutil.PersonUtil;
@@ -102,6 +112,87 @@ public class AddressBookParserTest {
 
         TagCommand command = (TagCommand) parser.parseCommand(userInput);
         assertEquals(expectedCommand, command);
+    }
+
+    @Test
+    public void parseCommand_untag() throws Exception {
+        HashSet<Tag> tagsToRemove = new HashSet<>(Arrays.asList(new Tag(new TagName("colleague")),
+                new Tag(new TagName("gym"))));
+        String userInput = UntagCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased() + " t/gym t/colleague";
+        UntagCommand expectedCommand = new UntagCommand(INDEX_FIRST_PERSON, tagsToRemove);
+
+        UntagCommand command = (UntagCommand) parser.parseCommand(userInput);
+        assertEquals(expectedCommand, command);
+    }
+
+    @Test
+    public void parseCommand_createTag() throws Exception {
+        Tag tagToCreate = new Tag(new TagName("colleague"));
+        String userInput = CreateTagCommand.COMMAND_WORD + " t/colleague";
+        CreateTagCommand expectedCommand = new CreateTagCommand(tagToCreate);
+
+        CreateTagCommand command = (CreateTagCommand) parser.parseCommand(userInput);
+        assertEquals(expectedCommand, command);
+    }
+
+    @Test
+    public void parseCommand_deleteTag() throws Exception {
+        Tag tagToDelete = new Tag(new TagName("vendor"));
+        String userInput = DeleteTagCommand.COMMAND_WORD + " t/vendor";
+        DeleteTagCommand expectedCommand = new DeleteTagCommand(tagToDelete);
+
+        DeleteTagCommand command = (DeleteTagCommand) parser.parseCommand(userInput);
+        assertEquals(expectedCommand, command);
+    }
+
+    @Test
+    public void parseCommand_createWedding() throws Exception {
+        Wedding weddingToCreate = new Wedding(new WeddingName("Wedding 19"));
+        String userInput = CreateWeddingCommand.COMMAND_WORD + " w/Wedding 19";
+        CreateWeddingCommand expectedCommand = new CreateWeddingCommand(weddingToCreate);
+
+        CreateWeddingCommand command = (CreateWeddingCommand) parser.parseCommand(userInput);
+        assertEquals(expectedCommand, command);
+    }
+
+    @Test
+    public void parseCommand_deleteWedding() throws Exception {
+        Wedding weddingToDelete = new Wedding(new WeddingName("Joe's Wedding"));
+        String userInput = DeleteWeddingCommand.COMMAND_WORD + " w/Joe's Wedding";
+        DeleteWeddingCommand expectedCommand = new DeleteWeddingCommand(weddingToDelete);
+
+        DeleteWeddingCommand command = (DeleteWeddingCommand) parser.parseCommand(userInput);
+        assertEquals(expectedCommand, command);
+    }
+
+    @Test
+    public void parseCommand_assignWedding() throws Exception {
+        HashSet<Wedding> weddingsToAdd = new HashSet<>(Arrays.asList(new Wedding(new WeddingName("Wedding 19")),
+                new Wedding(new WeddingName("Joe's Wedding"))));
+        String userInput = AssignWeddingCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased()
+                + " w/Wedding 19 w/Joe's Wedding";
+        AssignWeddingCommand expectedCommand = new AssignWeddingCommand(INDEX_FIRST_PERSON, weddingsToAdd);
+
+        AssignWeddingCommand command = (AssignWeddingCommand) parser.parseCommand(userInput);
+        assertEquals(expectedCommand, command);
+    }
+
+    @Test
+    public void parseCommand_unassignWedding() throws Exception {
+        HashSet<Wedding> weddingsToRemove = new HashSet<>(Arrays.asList(new Wedding(new WeddingName("Wedding 19")),
+                new Wedding(new WeddingName("Joe's Wedding"))));
+        String userInput = UnassignWeddingCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased()
+                + " w/Wedding 19 w/Joe's Wedding";
+        UnassignWeddingCommand expectedCommand = new UnassignWeddingCommand(INDEX_FIRST_PERSON, weddingsToRemove);
+
+        UnassignWeddingCommand command = (UnassignWeddingCommand) parser.parseCommand(userInput);
+        assertEquals(expectedCommand, command);
+    }
+
+    @Test
+    public void parseCommand_listWeddings() throws Exception {
+        assertTrue(parser.parseCommand(ListWeddingsCommand.COMMAND_WORD) instanceof ListWeddingsCommand);
+        assertTrue(parser.parseCommand(ListWeddingsCommand.COMMAND_WORD + " 3") instanceof ListWeddingsCommand);
     }
 
     @Test


### PR DESCRIPTION
Adds the ```list-weddings``` command to show a list of weddings in same format as the ```Person``` list.

**NOTE: To return to person view, use ```list``` command.**

Commands do not change depending on the view (*i.e., command ```delete 2``` in wedding view will still remove the 2nd ```Person```, not the 2nd ```Wedding```*)

Fixes #105 