### PR TITLE
Fix user message typos

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -119,7 +119,7 @@ public class Messages {
     public static final String MESSAGE_FORCE_UNASSIGN_VENDOR = "Use f/ to force the unassignment of vendors."
             + " This will unassign all tasks currently with the Vendor.";
     public static final String MESSAGE_UNASSIGN_VENDOR_FAILURE_TASK_EXISTS = "The Vendor: %1$s still has tasks"
-            + " assigned to them.";
+            + " assigned to them";
     public static final String MESSAGE_UNASSIGN_VENDOR_FAILURE_NOT_VENDOR = "%1$s is not a vendor.";
     public static final String MESSAGE_UNASSIGN_VENDOR_SUCCESS = "%1$s has been unassigned and is no longer a vendor.";
 

--- a/src/main/java/seedu/address/logic/commands/vendor/AssignVendorCommand.java
+++ b/src/main/java/seedu/address/logic/commands/vendor/AssignVendorCommand.java
@@ -25,7 +25,7 @@ public class AssignVendorCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Assigns the person identified by the index number used in the last person listing "
             + "as a vendor.\n"
-            + "Parameters: INDEX (must be a positive integer) "
+            + "Parameters: INDEX (must be a positive integer) \n"
             + "Example: " + COMMAND_WORD + " 1 ";
 
     private final Index targetIndex;


### PR DESCRIPTION
Fixing minor typos in prompt messages.

Deletion of period from `MESSAGE_UNASSIGN_VENDOR_FAILURE_TASK_EXISTS` required as an extra period is added when used.